### PR TITLE
pyansys to ansys actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
     needs: [docs]
     steps:
       - name: "Upload development documentation"
-        uses: pyansys/actions/doc-deploy-dev@v4
+        uses: ansys/actions/doc-deploy-dev@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: "Build Package"
-        uses: pyansys/pydpf-actions/build_package@v2.3
+        uses: ansys/pydpf-actions/build_package@v2.3
         with:
           python-version: ${{ matrix.python-version }}
           ANSYS_VERSION: ${{env.ANSYS_VERSION}}
@@ -86,7 +86,7 @@ jobs:
           standalone_suffix: ${{ inputs.standalone_suffix }}
 
       - name: "Prepare Testing Environment"
-        uses: pyansys/pydpf-actions/prepare_tests@v2.3
+        uses: ansys/pydpf-actions/prepare_tests@v2.3
         with:
           DEBUG: true
 
@@ -95,7 +95,7 @@ jobs:
         run: pip list
 
       - name: "Test Docstrings"
-        uses: pyansys/pydpf-actions/test_docstrings@v2.3
+        uses: ansys/pydpf-actions/test_docstrings@v2.3
         with:
           MODULE: ${{env.MODULE}}
           PACKAGE_NAME: ${{env.PACKAGE_NAME}}
@@ -108,7 +108,7 @@ jobs:
           pytest $DEBUG --cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
       - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+        uses: ansys/pydpf-actions/kill-dpf-servers@v2.3
         if: always()
 
       - name: "Upload Test Results"
@@ -142,7 +142,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: "Build Package"
-        uses: pyansys/pydpf-actions/build_package@v2.3
+        uses: ansys/pydpf-actions/build_package@v2.3
         with:
           python-version: ${{ matrix.python-version }}
           ANSYS_VERSION: ${{matrix.ANSYS_VERSION}}
@@ -162,7 +162,7 @@ jobs:
         if: matrix.ANSYS_VERSION == '221'
 
       - name: "Prepare Testing Environment"
-        uses: pyansys/pydpf-actions/prepare_tests@v2.3
+        uses: ansys/pydpf-actions/prepare_tests@v2.3
         with:
           DEBUG: true
 
@@ -177,7 +177,7 @@ jobs:
           pytest $DEBUG --cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
       - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+        uses: ansys/pydpf-actions/kill-dpf-servers@v2.3
         if: always()
 
       - name: "Upload Test Results"

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -70,7 +70,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: "Build Package"
-        uses: pyansys/pydpf-actions/build_package@v2.3
+        uses: ansys/pydpf-actions/build_package@v2.3
         with:
           python-version: ${{ matrix.python-version }}
           ANSYS_VERSION: ${{env.ANSYS_VERSION}}
@@ -83,7 +83,7 @@ jobs:
           standalone_suffix: ".pre1"
 
       - name: "Prepare Testing Environment"
-        uses: pyansys/pydpf-actions/prepare_tests@v2.3
+        uses: ansys/pydpf-actions/prepare_tests@v2.3
         with:
           DEBUG: true
 
@@ -92,7 +92,7 @@ jobs:
         run: pip list
 
       - name: "Test Docstrings"
-        uses: pyansys/pydpf-actions/test_docstrings@v2.3
+        uses: ansys/pydpf-actions/test_docstrings@v2.3
         with:
           MODULE: ${{env.MODULE}}
           PACKAGE_NAME: ${{env.PACKAGE_NAME}}
@@ -105,7 +105,7 @@ jobs:
           pytest $DEBUG --cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
       - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+        uses: ansys/pydpf-actions/kill-dpf-servers@v2.3
         if: always()
 
       - name: "Upload Test Results"
@@ -138,7 +138,7 @@ jobs:
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
       - name: "Build Package"
-        uses: pyansys/pydpf-actions/build_package@v2.3
+        uses: ansys/pydpf-actions/build_package@v2.3
         with:
           python-version: ${{ matrix.python-version }}
           ANSYS_VERSION: ${{matrix.ANSYS_VERSION}}
@@ -158,7 +158,7 @@ jobs:
         if: matrix.ANSYS_VERSION == '221'
 
       - name: "Prepare Testing Environment"
-        uses: pyansys/pydpf-actions/prepare_tests@v2.3
+        uses: ansys/pydpf-actions/prepare_tests@v2.3
         with:
           DEBUG: true
 
@@ -173,7 +173,7 @@ jobs:
           pytest $DEBUG --cov=ansys.dpf.${{env.MODULE}} --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
       - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+        uses: ansys/pydpf-actions/kill-dpf-servers@v2.3
         if: always()
 
       - name: "Upload Test Results"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: "Build Package"
         id: build-package
-        uses: pyansys/pydpf-actions/build_package@v2.3
+        uses: ansys/pydpf-actions/build_package@v2.3
         with:
           python-version: ${{ inputs.python_version }}
           ANSYS_VERSION: ${{inputs.ANSYS_VERSION}}
@@ -218,5 +218,5 @@ jobs:
           path: PDF-doc-${{env.PACKAGE_NAME}}.zip
 
       - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+        uses: ansys/pydpf-actions/kill-dpf-servers@v2.3
         if: always()

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -97,7 +97,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Build Package"
-        uses: pyansys/pydpf-actions/build_package@v2.3
+        uses: ansys/pydpf-actions/build_package@v2.3
         with:
           python-version: ${{ matrix.python-version }}
           ANSYS_VERSION: ${{inputs.ANSYS_VERSION}}
@@ -110,7 +110,7 @@ jobs:
           standalone_suffix: ${{ inputs.standalone_suffix }}
 
       - name: "Prepare Testing Environment"
-        uses: pyansys/pydpf-actions/prepare_tests@v2.3
+        uses: ansys/pydpf-actions/prepare_tests@v2.3
         with:
           DEBUG: true
 
@@ -126,5 +126,5 @@ jobs:
           python run_examples.py
 
       - name: "Kill all servers"
-        uses: pyansys/pydpf-actions/kill-dpf-servers@v2.3
+        uses: ansys/pydpf-actions/kill-dpf-servers@v2.3
         if: always()

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy the stable documentation
-        uses: pyansys/actions/doc-deploy-stable@v4
+        uses: ansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Loading a simulation (defined by its result files) allows you to extract simulat
 as results and then apply postprocessing operations on it.
 
 This module leverages the PyDPF-Core project's ``ansys-dpf-core`` package, which is
-available at [PyDPF-Core GitHub](https://github.com/pyansys/pydpf-core).
+available at [PyDPF-Core GitHub](https://github.com/ansys/pydpf-core).
 Use the ``ansys-dpf-core`` package for building more advanced and customized workflows
 using Ansys DPF.
 
@@ -34,7 +34,7 @@ pip install ansys-dpf-post
 You can also clone and install this package with this code:
 
 ```
-git clone https://github.com/pyansys/pydpf-post
+git clone https://github.com/ansys/pydpf-post
 cd pydpf-post
 pip install . --user
 ```
@@ -68,12 +68,12 @@ To load a simulation to extract and postprocess results, use this code:
 ```pycon
 >>> displacement.plot()
 ```
-![Example Displacement plot Crankshaft](https://github.com/pyansys/dpf-post/raw/master/docs/source/images/crankshaft_disp.png)
+![Example Displacement plot Crankshaft](https://github.com/ansys/dpf-post/raw/master/docs/source/images/crankshaft_disp.png)
 ```pycon
 >>> stress_eqv = simulation.stress_eqv_von_mises_nodal()
 >>> stress_eqv.plot()
 ```
-![Example Stress plot Crankshaft](https://github.com/pyansys/dpf-post/raw/master/docs/source/images/crankshaft_stress.png)
+![Example Stress plot Crankshaft](https://github.com/ansys/dpf-post/raw/master/docs/source/images/crankshaft_stress.png)
 
 To run PyDPF-Post with Ansys versions 2021 R1 and 2022 R2, use this code to
 start the legacy PyDPF-Post tools::
@@ -85,9 +85,9 @@ start the legacy PyDPF-Post tools::
 >>> stress = solution.stress()
 >>> stress.eqv.plot_contour(show_edges=False)
 ```
-![Example Stress plot Crankshaft](https://github.com/pyansys/dpf-post/raw/master/docs/source/images/crankshaft_stress.png)
+![Example Stress plot Crankshaft](https://github.com/ansys/dpf-post/raw/master/docs/source/images/crankshaft_stress.png)
 
 ## License
 
 ``PyDPF-Post`` is licensed under the MIT license. For more information, see the
-[LICENSE](https://github.com/pyansys/dpf-post/raw/master/LICENSE).
+[LICENSE](https://github.com/ansys/dpf-post/raw/master/LICENSE).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -158,7 +158,7 @@ html_theme = "ansys_sphinx_theme"
 html_logo = pyansys_logo_black
 html_facivon = ansys_favicon
 html_theme_options = {
-    "github_url": "https://github.com/pyansys/pydpf-post",
+    "github_url": "https://github.com/ansys/pydpf-post",
     "show_prev_next": False,
     "show_breadcrumbs": True,
     "additional_breadcrumbs": [

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -25,7 +25,7 @@ development mode, run:
 Post issues
 -----------
 
-Use the `PyDPF-Post Issues <https://github.com/pyansys/pydpf-post/issues>`_
+Use the `PyDPF-Post Issues <https://github.com/ansys/pydpf-post/issues>`_
 page to submit questions, report bugs, and request new features.
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -32,7 +32,7 @@ Install without internet
 If you are unable to install PyDPF-Post on the host machine using ``pip`` due to
 network isolation, you can download the wheelhouse corresponding to your platform
 and Python interpreter version. To obtain the latest release, go to the **Assets** section
-for the `latest PyDPF-Post release <https://github.com/pyansys/pydpf-post/releases/latest>`_ on GitHub.
+for the `latest PyDPF-Post release <https://github.com/ansys/pydpf-post/releases/latest>`_ on GitHub.
 
 The wheelhouse is a ZIP file containing Python wheels for all the packages PyDPF-Post requires to run.
 To install PyDPF-Post using the downloaded wheelhouse, unzip the wheelhouse to a local directory and

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ to extract simulation metadata as well as results and then apply postprocessing
 operations on it.
 
 This module leverages the PyDPF-Core project's ``ansys-dpf-core`` package, which is
-available at `PyDPF-Core GitHub <https://github.com/pyansys/pydpf-core>`_.
+available at `PyDPF-Core GitHub <https://github.com/ansys/pydpf-core>`_.
 Use the ``ansys-dpf-core`` package for building more advanced and customized
 workflows using DPF.
 
@@ -102,7 +102,7 @@ The PyDPF-Post API automates the use of chained DPF operators to make
 postprocessing easier. The PyDPF-Post documentation describes how you can
 use operators to compute results. This allows you to build your own custom,
 low-level scripts to enable fast postprocessing of potentially multi-gigabyte
-models using `PyDPF-Core <https://github.com/pyansys/pydpf-core>`_.
+models using `PyDPF-Core <https://github.com/ansys/pydpf-core>`_.
 
 
 .. toctree::

--- a/docs/source/pydpf-post_clone_install.rst
+++ b/docs/source/pydpf-post_clone_install.rst
@@ -1,5 +1,5 @@
 .. code::
 
-    git clone https://github.com/pyansys/pydpf-post
+    git clone https://github.com/ansys/pydpf-post
     cd pydpf-post
     pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
 ]
 dependencies = [
-    "ansys-dpf-core @ git+https://git@github.com/pyansys/pydpf-core.git",
+    "ansys-dpf-core @ git+https://git@github.com/ansys/pydpf-core.git",
     "scooby",
 ]
 classifiers = [
@@ -38,7 +38,7 @@ classifiers = [
 name = "ansys.dpf.post"
 
 [project.urls]
-Source = "https://github.com/pyansys/pydpf-post"
+Source = "https://github.com/ansys/pydpf-post"
 
 [project.optional-dependencies]
 plotting = [


### PR DESCRIPTION
PyAnsys projects have all been moved to Ansys organization as of May 16th.
All references to `pyansys` organization are changed to `ansys`.