### PR TITLE
Remove CI 221 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ["232", "231", "222", "221"]
+        ANSYS_VERSION: ["232", "231", "222"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -125,7 +125,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ["232", "231", "222", "221"]
+        ANSYS_VERSION: ["232", "231", "222"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The new packaging strategy for `ansys-dpf-core==0.9.1` dependencies is not compatible with 221