### PR TITLE
Remove explicit string test managed by PyDPF-Core

### DIFF
--- a/src/ansys/dpf/post/simulation.py
+++ b/src/ansys/dpf/post/simulation.py
@@ -102,8 +102,7 @@ class Simulation(ABC):
         >>> from ansys.dpf import post
         >>> from ansys.dpf.post import examples
         >>> simulation = post.load_simulation(examples.static_rst)
-        >>> print(simulation.results) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-        ['displacement\nOperator name: "U"\n...Units: degc\n']
+        >>> print(simulation.results)
         """
         return [
             str(result) for result in self._model.metadata.result_info.available_results


### PR DESCRIPTION
Remove explicit string test on `simulation.results` Docstring since it is dealt with and tested in `ansys-dpf-core`.

See https://github.com/ansys/pydpf-core/pull/978