### PR TITLE
Set Pyvista < 0.40.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Source = "https://github.com/ansys/pydpf-post"
 
 [project.optional-dependencies]
 plotting = [
-    "pyvista>=0.24.0",
+    "pyvista>=0.24.0, <0.40.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
The latest release of PyVista apprently introduces breaking changes which make the pipelines fail.
An active work for support of the new 0.40.0 seems necessary.