### PR TITLE
Deal with size 6 as well as size 7 unit systems

### DIFF
--- a/src/ansys/dpf/post/simulation.py
+++ b/src/ansys/dpf/post/simulation.py
@@ -335,14 +335,15 @@ class Simulation(ABC):
         result_units = us.split(": ")[1].split(", ")
         if self._units is None:
             self._units = {
-                "time": result_units[3],
                 "length": result_units[0],
                 "mass": result_units[1],
                 "force": result_units[2],
-                "temperature": result_units[6],
-                "potential": result_units[4],
-                "current": result_units[5],
+                "time": result_units[3],
+                "current": result_units[-2],
+                "temperature": result_units[-1],
             }
+            if len(result_units) > 6:
+                self._units["potential"] = result_units[4]
         return self._units
 
     def __str__(self):


### PR DESCRIPTION
It seems ANSYS result files with the `NMM` unit system appear in PyDPF with only 6 units instead of 7 for `MKS`.
The electrical potential unit is missing.
While investigating whether this is a bug, this PR patches this so CI can still run.