### PR TITLE
Fix result query on zones

### DIFF
--- a/examples/04-Fluid-Examples/00-explore-fluid-simulation.py
+++ b/examples/04-Fluid-Examples/00-explore-fluid-simulation.py
@@ -88,3 +88,10 @@ water_temperature = simulation.temperature(phases=["Water at 25 C"])
 # water_temperature = simulation.temperature(phases=[2])
 print(water_temperature)
 # # The dataframe obtained now only stores data for the water phase.
+
+###############################################################################
+# To extract a result on given zones use the 'zone_ids' argument
+# or the 'qualifiers' dictionary argument with key 'zone'
+# Here we request and plot the temperature on all face zones
+face_temperature = simulation.temperature(zone_ids=list(simulation.face_zones.keys()))
+face_temperature.plot()

--- a/src/ansys/dpf/post/dataframe.py
+++ b/src/ansys/dpf/post/dataframe.py
@@ -826,14 +826,6 @@ class DataFrame:
             #     )
             # )
             # return None
-        field_to_plot = fields[0]
-        # If multi-component, take the norm
-        if field_to_plot.component_count > 1:
-            field_to_plot = dpf.operators.math.norm(
-                field_to_plot, server=field_to_plot._server
-            ).eval()
-        plotter = DpfPlotter(**kwargs)
-        plotter.add_field(field=fields[0], **kwargs)
         # for field in fields:
         if len(fields) > 1:
             # try:
@@ -851,6 +843,15 @@ class DataFrame:
             # )
             # return None
         # field.plot(text="debug")
+        field_to_plot = fields[0]
+        # If multi-component, take the norm
+        if field_to_plot.component_count > 1:
+            field_to_plot = dpf.operators.math.norm(
+                field_to_plot, server=field_to_plot._server
+            ).eval()
+        plotter = DpfPlotter(**kwargs)
+        plotter.add_field(field=field_to_plot, **kwargs)
+
         return plotter.show_figure(
             title=kwargs.pop("title", str(label_space)), **kwargs
         )

--- a/src/ansys/dpf/post/fluid_simulation.py
+++ b/src/ansys/dpf/post/fluid_simulation.py
@@ -438,7 +438,7 @@ class FluidSimulation(Simulation):
             # Results have been queried on the whole mesh,
             # A MeshProvider is required to give the mesh as input of the source operator
             mesh_provider_op = self._model.operator("mesh_provider")
-            result_op.connect(7, mesh_provider_op.outputs.mes)
+            result_op.connect(7, mesh_provider_op.outputs.mesh)
             wf.add_operator(mesh_provider_op)
 
         out = result_op.outputs.fields_container

--- a/src/ansys/dpf/post/fluid_simulation.py
+++ b/src/ansys/dpf/post/fluid_simulation.py
@@ -432,8 +432,14 @@ class FluidSimulation(Simulation):
             # A MeshesProvider is required to give meshes as input of the source operator
             meshes_provider_op = self._model.operator("meshes_provider")
             meshes_provider_op.connect(25, query_regions_meshes)
-            wf.add_operator(meshes_provider_op)
             result_op.connect(7, meshes_provider_op.outputs.meshes)
+            wf.add_operator(meshes_provider_op)
+        else:
+            # Results have been queried on the whole mesh,
+            # A MeshProvider is required to give the mesh as input of the source operator
+            mesh_provider_op = self._model.operator("mesh_provider")
+            result_op.connect(7, mesh_provider_op.outputs.mes)
+            wf.add_operator(mesh_provider_op)
 
         out = result_op.outputs.fields_container
         # Its inputs are selected as workflow inputs for merging with selection workflows

--- a/tests/test_fluid_simulation.py
+++ b/tests/test_fluid_simulation.py
@@ -429,3 +429,24 @@ class TestFluidSimulation:
 """  # noqa: W291, E501
         assert str(result) == ref
         result.plot()
+
+    def test_plot_result_on_zones(self, fluent_simulation):
+        temperature = fluent_simulation.temperature(
+            zone_ids=list(fluent_simulation.cell_zones.keys())
+        )
+        temperature.plot()
+
+        temperature = fluent_simulation.temperature(
+            qualifiers={"zone": list(fluent_simulation.cell_zones.keys())}
+        )
+        temperature.plot()
+
+        temperature = fluent_simulation.temperature(
+            zone_ids=list(fluent_simulation.face_zones.keys())
+        )
+        temperature.plot()
+
+        temperature = fluent_simulation.temperature(
+            qualifiers={"zone": list(fluent_simulation.face_zones.keys())}
+        )
+        temperature.plot()


### PR DESCRIPTION
Add the `MeshesProvider` operator to have meshes associated to the resulting fields when using a zone_scoping input