### PR TITLE
Remove 221 from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ["232", "231", "222", "221"]
+        ANSYS_VERSION: ["232", "231", "222"]
 
     steps:
       - uses: actions/checkout@v3
@@ -151,14 +151,6 @@ jobs:
           dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
           install_extras: plotting
           wheel: false
-
-      - name: "Install ansys-grpc-dpf==0.4.0"
-        shell: bash
-        run: |
-          pip install ansys-grpc-dpf==0.4.0
-          pip uninstall -y protobuf
-          pip install "protobuf<4.0"
-        if: matrix.ANSYS_VERSION == '221'
 
       - name: "Prepare Testing Environment"
         uses: ansys/pydpf-actions/prepare_tests@v2.3

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -127,7 +127,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ["232", "231", "222", "221"]
+        ANSYS_VERSION: ["232", "231", "222"]
 
     steps:
       - uses: actions/checkout@v3
@@ -150,14 +150,6 @@ jobs:
           install_extras: plotting
           wheel: false
           extra-pip-args: ${{ env.extra }}
-
-      - name: "Install ansys-grpc-dpf==0.4.0"
-        shell: bash
-        run: |
-          pip install ansys-grpc-dpf==0.4.0
-          pip uninstall -y protobuf
-          pip install "protobuf<4.0"
-        if: matrix.ANSYS_VERSION == '221'
 
       - name: "Prepare Testing Environment"
         uses: ansys/pydpf-actions/prepare_tests@v2.3


### PR DESCRIPTION
Ansys 2022 R1 is no longer compatible with `ansys-dpf-core`.