### PR TITLE
Fix results extraction for simulation object with given server

### DIFF
--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -379,7 +379,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             )
             for i_field in range(len(fc)):
                 bind_support_op = dpf.operators.utility.bind_support(
-                    fc[i_field], submesh
+                    fc[i_field],
+                    submesh,
+                    server=fc._server,
                 )
                 fc.add_field(fc.get_label_space(i_field), bind_support_op.eval())
 

--- a/src/ansys/dpf/post/simulation.py
+++ b/src/ansys/dpf/post/simulation.py
@@ -619,6 +619,7 @@ class Simulation(ABC):
         merge_op = dpf.operators.utility.merge_fields_by_label(
             fields_container=shell_layer_op.outputs.fields_container_as_fields_container,
             label="eltype",
+            server=fc._server,
         )
 
         # Expose output
@@ -643,7 +644,9 @@ class Simulation(ABC):
             if submesh is not None:
                 for i_field in range(len(fc)):
                     bind_support_op = dpf.operators.utility.bind_support(
-                        fc[i_field], submesh
+                        fc[i_field],
+                        submesh,
+                        server=fc._server,
                     )
                     fc.add_field(fc.get_label_space(i_field), bind_support_op.eval())
         if unit == "":

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -158,6 +158,16 @@ class TestStaticMechanicalSimulation:
         assert "base_sector" not in result.columns.names
         assert "stage" not in result.columns.names
 
+    @pytest.mark.skipif(
+        not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0,
+        reason="Available starting DPF 4.0",
+    )
+    def test_with_grpc_server(self, static_rst, grpc_server):
+        simulation = post.StaticMechanicalSimulation(static_rst, server=grpc_server)
+        assert simulation._model._server != dpf.SERVER
+        _ = simulation.displacement()
+        _ = simulation.displacement(skin=True)
+
     def test_times_argument(self, static_simulation):
         _ = static_simulation.displacement(times=1)
         _ = static_simulation.displacement(times=1.0)
@@ -2074,6 +2084,18 @@ class TestHarmonicMechanicalSimulation:
         # print(result)
         assert "base_sector" not in result.columns.names
         assert "stage" not in result.columns.names
+
+    @pytest.mark.skipif(
+        not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0,
+        reason="Available starting DPF 4.0",
+    )
+    def test_with_grpc_server(self, complex_model, grpc_server):
+        simulation = post.HarmonicMechanicalSimulation(
+            complex_model, server=grpc_server
+        )
+        assert simulation._model._server != dpf.SERVER
+        _ = simulation.displacement()
+        _ = simulation.displacement(skin=True)
 
     def test_displacement(self, harmonic_simulation):
         # print(harmonic_simulation)


### PR DESCRIPTION
In a couple of places the server wasn't passed to the operator. If you created the simulation object with a non-global server, that would trigger the startup of a new server.