### PR TITLE
Vale ignore RST roles

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -30,3 +30,13 @@ BasedOnStyles = Vale, Google
 # Removing Google-specific rule - Not applicable under some circumstances
 Google.WordList = NO
 Google.Colons = NO
+
+[formats]
+# Format associations appear under
+# the optional "formats" section.
+
+[*]
+# Format-specific settings appear
+# under a user-provided "glob"
+# pattern.
+TokenIgnores = (:class:\x60.*\x60|:meth:\x60.*\x60|:py:class:\x60.*\x60|:py:meth:\x60.*\x60)

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -39,4 +39,5 @@ Google.Colons = NO
 # Format-specific settings appear
 # under a user-provided "glob"
 # pattern.
-TokenIgnores = (:class:\x60.*\x60|:meth:\x60.*\x60|:py:class:\x60.*\x60|:py:meth:\x60.*\x60)
+TokenIgnores = (:.*:\x60.*\x60)
+


### PR DESCRIPTION
An update of Vale now triggers errors on module names in `:class:` and `:meth:` roles.
Edit: also trigerring for `:ref:`, so switched to ignoring all roles (`:*:`).