### PR TITLE
Clean init file

### DIFF
--- a/src/ansys/dpf/post/__init__.py
+++ b/src/ansys/dpf/post/__init__.py
@@ -55,7 +55,3 @@ from ansys.dpf.post.transient_mechanical_simulation import (  # noqa: F401
 
 # this must be after some ansys.dpf.post import
 __version__ = importlib_metadata.version("ansys-dpf-post")
-
-if hasattr(core, "settings") and hasattr(core.settings, "set_default_pyvista_config"):
-    core.settings.set_default_pyvista_config()
-# dpf.core.start_local_server()

--- a/src/ansys/dpf/post/__init__.py
+++ b/src/ansys/dpf/post/__init__.py
@@ -56,11 +56,6 @@ from ansys.dpf.post.transient_mechanical_simulation import (  # noqa: F401
 # this must be after some ansys.dpf.post import
 __version__ = importlib_metadata.version("ansys-dpf-post")
 
-
-if hasattr(core, "settings") and hasattr(
-    core.settings, "set_dynamic_available_results_capability"
-):
-    core.settings.set_dynamic_available_results_capability(False)
 if hasattr(core, "settings") and hasattr(core.settings, "set_default_pyvista_config"):
     core.settings.set_default_pyvista_config()
 # dpf.core.start_local_server()


### PR DESCRIPTION
Remove call to `core.settings.set_dynamic_available_results_capability(False)`

@cbellot000 do you remember why this was put there? It dates back to before the available GH/git history.

@FedericoNegri reported it being there and not necessarily being practical for the user in some situations.