### PR TITLE
Switch release CI to DPF 2052.1.pre0

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -11,7 +11,7 @@ on:
       standalone_branch_suffix:
         description: 'Suffix of the branch on standalone'
         required: false
-        default: '.pre1'
+        default: '.pre0'
 
 #┌───────────── minute (0 - 59)
 #│ ┌───────────── hour (0 - 23)
@@ -28,7 +28,7 @@ env:
   MODULE: 'post'
   DOCUMENTATION_CNAME: 'post.docs.pyansys.com'
   MAIN_PYTHON_VERSION: '3.10'
-  ANSYS_VERSION: '242'
+  ANSYS_VERSION: '251'
 
 jobs:
   debug:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ANSYS_VERSION: ["242"]
+        ANSYS_VERSION: ["251"]
         python-version: ["3.9", "3.10", "3.11"]
         os: ["windows-latest", "ubuntu-latest"]
 
@@ -87,7 +87,7 @@ jobs:
           install_extras: plotting
           wheel: true
           wheelhouse: true
-          standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+          standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
 
       - name: "Prepare Testing Environment"
         uses: ansys/pydpf-actions/prepare_tests@v2.3
@@ -132,7 +132,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ["241", "232", "231", "222"]
+        ANSYS_VERSION: ["242", "241", "232", "231", "222"]
 
     steps:
       - uses: actions/checkout@v4
@@ -188,17 +188,17 @@ jobs:
   examples:
     uses: ./.github/workflows/examples.yml
     with:
-      ANSYS_VERSION: '242'
+      ANSYS_VERSION: '251'
       python_versions: '["3.10"]'
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
     secrets: inherit
 
   docs:
     uses: ./.github/workflows/docs.yml
     with:
-      ANSYS_VERSION: '242'
+      ANSYS_VERSION: '251'
       python_version: "3.10"
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
       event_name: ${{ github.event_name }}
     secrets: inherit
 


### PR DESCRIPTION
Bumps DPF Server to `2025.1.pre0` in the release CI.
Release action run: https://github.com/ansys/pydpf-post/actions/runs/9988506484