### PR TITLE
Only run docstring tests for the main Python version tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: "Test Docstrings"
         uses: ansys/pydpf-actions/test_docstrings@v2.3
+        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION }}
         with:
           MODULE: ${{env.MODULE}}
           PACKAGE_NAME: ${{env.PACKAGE_NAME}}


### PR DESCRIPTION
This solves artifact conflicts due to naming.