### PR TITLE
Add a release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+    exclude:
+      authors:
+        - dependabot[bot]
+    categories:
+      - title: Enhancements
+        labels:
+          - enhancement
+      - title: Bug fixes
+        labels:
+          - bug
+      - title: Documentation
+        labels:
+          - documentation
+      - title: Examples
+        labels:
+          - examples
+      - title: CI/CD
+        labels:
+          - CI/CD
+      - title: Maintenance
+        labels:
+          - maintenance
+          - dependencies


### PR DESCRIPTION
This adds sections to the automatic release notes based on PR labels.
It also excludes PRs from `dependabot` to stop bloating the release notes.
Whenever modifications were required for a dependency bump, the PR should still appear due to the second author (TBC). 