### PR TITLE
Update face IDs list reference in test_spatial_selection_select_faces_of_elements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,6 +222,10 @@ def license_context():
         yield
 
 
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_9_1 = meets_version(
+    get_server_version(core._global_server()), "9.1"
+)
+
 SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_9_0 = meets_version(
     get_server_version(core._global_server()), "9.0"
 )

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -99,7 +99,7 @@ class TestSpatialSelectionFaces:
         )
         scoping = selection._evaluate_on(fluent_simulation)
         assert scoping.location == post.locations.faces
-        assert np.allclose(scoping.ids, [11479, 11500, -1, 11502, 11503])
+        assert np.allclose(scoping.ids, [12481, 12502, 39941, 43681, 12504, 12505])
 
 
 #

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -6,7 +6,10 @@ from ansys.dpf import core as dpf
 from ansys.dpf import post
 from ansys.dpf.post import examples
 from ansys.dpf.post.selection import SpatialSelection
-from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0
+from conftest import (
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0,
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_9_1,
+)
 
 
 def test_spatial_selection_select_nodes(allkindofcomplexity):
@@ -99,7 +102,11 @@ class TestSpatialSelectionFaces:
         )
         scoping = selection._evaluate_on(fluent_simulation)
         assert scoping.location == post.locations.faces
-        assert np.allclose(scoping.ids, [12481, 12502, 39941, 43681, 12504, 12505])
+        if not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_9_1:
+            list_ref = [11479, 11500, -1, 11502, 11503]
+        else:
+            list_ref = [12481, 12502, 39941, 43681, 12504, 12505]
+        assert np.allclose(scoping.ids, list_ref)
 
 
 #


### PR DESCRIPTION
after bug fix server-side on management of faces for several mesh-related operators (for example `mesh_from_scoping`) 