### PR TITLE
Remove completely doc-index-stable from releaser.yml

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -97,21 +97,6 @@ jobs:
           doc-artifact-name: HTML-doc-ansys-dpf-post.zip
           decompress-artifact: true
 
-  doc-index-stable:
-    name: "Deploy stable docs index"
-    runs-on: ubuntu-latest
-    needs: upload_docs_release
-    steps:
-      - name: "Install Git and clone project"
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.checkout_ref || '' }}
-
-      - name: "Install the package requirements"
-        run: |
-          python3 -m venv .venv
-          .venv/bin/python -m pip install -e .
-
   update_ansys_lab_examples:
     uses: ./.github/workflows/ansys_lab.yml
     needs: get_latest_tag


### PR DESCRIPTION
Part of the step was kept but is useless and should be removed.