### PR TITLE
Update for numpy 2

### DIFF
--- a/src/ansys/dpf/post/mesh_info.py
+++ b/src/ansys/dpf/post/mesh_info.py
@@ -192,6 +192,6 @@ class FluidMeshInfo:
                 face_zone_ids = property_field.get_entity_data_by_id(
                     cell_zone_id
                 ).tolist()
-                result[cell_zone_id] = face_zone_ids
+                result[cell_zone_id.item()] = face_zone_ids
             self._cell_zones_to_face_zones = result
         return self._cell_zones_to_face_zones

--- a/src/ansys/dpf/post/mesh_info.py
+++ b/src/ansys/dpf/post/mesh_info.py
@@ -139,7 +139,7 @@ class FluidMeshInfo:
             string_field = self._core_object.get_property("face_zone_names")
             for zone_id in string_field.scoping.ids:
                 zone_name = string_field.get_entity_data_by_id(zone_id)[0]
-                zones[zone_id] = zone_name
+                zones[zone_id.item()] = zone_name
             self._face_zones = zones
         return self._face_zones
 
@@ -164,7 +164,7 @@ class FluidMeshInfo:
             string_field = self._core_object.body_names
             for zone_id in string_field.scoping.ids:
                 zone_name = string_field.get_entity_data_by_id(zone_id)[0]
-                zones[zone_id] = zone_name
+                zones[zone_id.item()] = zone_name
             self._cell_zones = zones
         return self._cell_zones
 


### PR DESCRIPTION
Switch `MeshInfo.cell_zones` and `MeshInfo.face_zones` keys to `int` instead of `np.int32`.

Starting with `numpy==2`, the `np.int32` is reported explicitly as such, making their representation pop up where used directly. To circumvent that, when building maps based on `scoping.ids`, take the underlying Python `int`.

See [here](https://github.com/ansys/pydpf-core/actions/runs/11727755035/job/32669608017?pr=1847#step:17:1082) for the failing checks when upgrading to `numpy==2`.