### PR TITLE
Fix to avoid checking duplicate ids for cyclic expansion

### DIFF
--- a/src/ansys/dpf/post/dpf_solution.py
+++ b/src/ansys/dpf/post/dpf_solution.py
@@ -89,8 +89,8 @@ class DpfSolution:
         Physics Type: ...
         Available results:
              -  displacement: Nodal Displacement
-             -  reaction_force: Nodal Force   
-             -  stress: ElementalNodal Stress 
+             -  reaction_force: Nodal Force
+             -  stress: ElementalNodal Stress
              -  elemental_volume: Elemental Volume
              -  stiffness_matrix_energy: Elemental Energy-stiffness matrix
              -  artificial_hourglass_energy: Elemental Hourglass Energy

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -3033,7 +3033,7 @@ class TestModalMechanicalSimulation:
         )
         assert len(result.index.mesh_index) == 2842
         assert len(result.columns.set_ids) == 1
-        assert np.allclose(result.max(axis="element_ids").array, [0.00620539]) 
+        assert np.allclose(result.max(axis="element_ids").array, [0.00620539])
 
     def test_disp_skin(self, frame_modal_simulation: post.ModalMechanicalSimulation):
         result = frame_modal_simulation.displacement(set_ids=[1], skin=True)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2439,7 +2439,13 @@ class TestModalMechanicalSimulation:
 
         displacement = simulation.displacement(expand_cyclic=True)
         assert "base_sector" not in displacement.columns.names
-        assert len(displacement.mesh_index) == 408
+        
+        print(displacement.scoping.ids)
+        
+        if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 :
+            assert len(displacement.mesh_index) == 304
+        else:
+            assert len(displacement.mesh_index) == 408
 
         with pytest.raises(
             ValueError,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2440,8 +2440,6 @@ class TestModalMechanicalSimulation:
         displacement = simulation.displacement(expand_cyclic=True)
         assert "base_sector" not in displacement.columns.names
         
-        print(displacement.scoping.ids)
-        
         if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 :
             assert len(displacement.mesh_index) == 304
         else:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2440,7 +2440,7 @@ class TestModalMechanicalSimulation:
         displacement = simulation.displacement(expand_cyclic=True)
         assert "base_sector" not in displacement.columns.names
         
-        if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 :
+        if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0:
             assert len(displacement.mesh_index) == 304
         else:
             assert len(displacement.mesh_index) == 408

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -3033,7 +3033,7 @@ class TestModalMechanicalSimulation:
         )
         assert len(result.index.mesh_index) == 2842
         assert len(result.columns.set_ids) == 1
-        assert np.allclose(result.max(axis="element_ids").array, [0.00620539])
+        assert np.allclose(result.max(axis="element_ids").array, [0.00620539]) 
 
     def test_disp_skin(self, frame_modal_simulation: post.ModalMechanicalSimulation):
         result = frame_modal_simulation.displacement(set_ids=[1], skin=True)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2439,7 +2439,6 @@ class TestModalMechanicalSimulation:
 
         displacement = simulation.displacement(expand_cyclic=True)
         assert "base_sector" not in displacement.columns.names
-        
         if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0:
             assert len(displacement.mesh_index) == 304
         else:


### PR DESCRIPTION
Fix to avoid checking duplicate ids for cyclic expansion