### PR TITLE
Revert "Add result scoping output (#802)"

### DIFF
--- a/src/ansys/dpf/post/result_workflows/_sub_workflows.py
+++ b/src/ansys/dpf/post/result_workflows/_sub_workflows.py
@@ -212,9 +212,6 @@ def _create_initial_result_workflow(
     initial_result_workflow.add_operator(forward_shell_layer_op)
     initial_result_workflow.set_input_name(_WfNames.shell_layer, forward_shell_layer_op)
 
-    forward_input_mesh_scoping_op = operators.utility.forward(server=server)
-    initial_result_workflow.add_operator(forward_input_mesh_scoping_op)
-
     # The next section is only needed, because the shell_layer selection does not
     # work for elemental and elemental nodal results.
     # If elemental results are requested with a chosen shell layer,
@@ -261,16 +258,8 @@ def _create_initial_result_workflow(
     initial_result_workflow.set_input_name(
         "time_scoping", initial_result_op.inputs.time_scoping
     )
-
     initial_result_workflow.set_input_name(
-        "mesh_scoping", forward_input_mesh_scoping_op
-    )
-    _connect_any(
-        initial_result_op.inputs.mesh_scoping, forward_input_mesh_scoping_op.outputs.any
-    )
-
-    initial_result_workflow.set_output_name(
-        _WfNames.result_scoping, forward_input_mesh_scoping_op.outputs.any
+        "mesh_scoping", initial_result_op.inputs.mesh_scoping
     )
 
     initial_result_workflow.set_input_name(_WfNames.read_cyclic, initial_result_op, 14)

--- a/src/ansys/dpf/post/selection.py
+++ b/src/ansys/dpf/post/selection.py
@@ -60,7 +60,6 @@ class _WfNames:
     skin_input_mesh = "skin_input_mesh"
     final_scoping = "final_scoping"
     result_scoping_by_body = "result_scoping_by_body"
-    result_scoping = "result_scoping"
     scoping_a = "scoping_a"
     scoping_b = "scoping_b"
     streams = "streams"


### PR DESCRIPTION
This reverts commit 0ffc134ec5171b841bf53d637ab972d30054eed2.

Forwarding does not work for the LS-Dyna result operator. Has been fixed differently.