### PR TITLE
fix(core): adapt to move of locations in ansys.dpf.core.common

### DIFF
--- a/src/ansys/dpf/post/result_workflows/_build_workflow.py
+++ b/src/ansys/dpf/post/result_workflows/_build_workflow.py
@@ -25,7 +25,7 @@ from typing import Callable, List, Optional, Union
 
 from ansys.dpf.core import Operator, Workflow, shell_layers
 from ansys.dpf.core.available_result import _result_properties
-from ansys.dpf.gate.common import locations
+from ansys.dpf.core.common import locations
 
 from ansys.dpf.post.result_workflows._component_helper import (
     ResultCategory,

--- a/src/ansys/dpf/post/result_workflows/_sub_workflows.py
+++ b/src/ansys/dpf/post/result_workflows/_sub_workflows.py
@@ -29,7 +29,7 @@ from ansys.dpf.core import (
     operators,
     shell_layers,
 )
-from ansys.dpf.gate.common import locations
+from ansys.dpf.core.common import locations
 
 from ansys.dpf.post.misc import _connect_any
 from ansys.dpf.post.result_workflows._utils import _CreateOperatorCallable, _Rescoping

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -38,7 +38,7 @@ from ansys.dpf.core import (
     operators,
     shell_layers,
 )
-from ansys.dpf.gate.common import locations
+from ansys.dpf.core.common import locations
 import numpy as np
 import pytest
 from pytest import fixture


### PR DESCRIPTION
Adapt to move of `locations` from `ansys.dpf.gate.common` to `ansys.dpf.core.common`.