### PR TITLE
ci: ci.yml and ci_release.yml use repository variable ANSYS_VERSIONS_RETRO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         os: ["windows-latest", "ubuntu-latest"]
         ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
         include:
-          - ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSION_LAST_RELEASED) }}
+          - ANSYS_VERSION: vars.ANSYS_VERSION_LAST_RELEASED
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         os: ["windows-latest", "ubuntu-latest"]
         ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
         include:
-          - ANSYS_VERSION: ${{ vars.ANSYS_VERSION_LAST_RELEASED }}
+          - ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSION_LAST_RELEASED) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ["252", "251", "242", "241", "232", "231", "222"]
+        ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
+        ANSYS_VERSION:
+          - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
+          - ${{ fromJson(vars.ANSYS_VERSION_LAST_RELEASED) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         os: ["windows-latest", "ubuntu-latest"]
         ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
         include:
-          - ANSYS_VERSION: vars.ANSYS_VERSION_LAST_RELEASED
+          - ANSYS_VERSION: 252
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,8 @@ jobs:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
         ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
+        include:
+          - ANSYS_VERSION: ${{ vars.ANSYS_VERSION_LAST_RELEASED }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         os: ["windows-latest", "ubuntu-latest"]
         ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
         include:
-          - ANSYS_VERSION: 252
+          - ANSYS_VERSION: "252"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,6 @@ jobs:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
         ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
-        include:
-          - ANSYS_VERSION: "252"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -135,7 +135,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os: ["windows-latest", "ubuntu-latest"]
-        ANSYS_VERSION: ["251", "242", "241", "232", "231", "222"]
+        ANSYS_VERSION: ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR makes the retro job in `ci.yml` run for versions in repository variables `ANSYS_VERSIONS_RETRO` and `ANSYS_VERSION_LAST_RELEASED`, as well as makes the retro job in `ci_release.yml` run for versions in repository variable `ANSYS_VERSIONS_RETRO`.