### PR TITLE
fix: proper LICENSE metadata for package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ version = "0.10.1.dev0"
 description = "PyDPF-Post Python library."
 readme = "README.md"
 requires-python = ">=3.9,<4.0"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
 ]


### PR DESCRIPTION
Currently, the license is not showing up properly for ansys-dpf-post. This is caused by the way in which the license is referred in the pyproject.toml file. It should be done in this way moving forward