### PR TITLE
ci(test): update default value of num fields in tests for BFE

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,10 @@ def license_context():
         yield
 
 
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 = meets_version(
+    get_server_version(core._global_server()), "11.0"
+)
+
 SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 = meets_version(
     get_server_version(core._global_server()), "10.0"
 )

--- a/tests/test_resultobject.py
+++ b/tests/test_resultobject.py
@@ -30,6 +30,7 @@ from ansys.dpf.post.result_data import ResultData
 from ansys.dpf.post.scalar import ComplexScalar, Scalar
 from ansys.dpf.post.tensor import ComplexTensor, Tensor
 from ansys.dpf.post.vector import ComplexVector, Vector
+from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0
 
 
 def test_scalar(allkindofcomplexity):
@@ -43,7 +44,10 @@ def test_scalar(allkindofcomplexity):
     )
     value = scalar.scalar
     assert isinstance(value, ResultData)
-    assert value.num_fields == 2
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        assert value.num_fields == 3
+    else:
+        assert value.num_fields == 2
     assert value[0].data[0] == 22.0
 
 
@@ -695,7 +699,10 @@ def test_temperature(allkindofcomplexity):
     # print(temp)
     assert temp._operator_name == "BFE"
     value = temp.scalar
-    assert value.num_fields == 2
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
+        assert value.num_fields == 3
+    else:
+        assert value.num_fields == 2
     assert value[0].data[0] == 22.0
     assert value[0].location == post.locations.nodal
     temp2 = solution.structural_temperature(


### PR DESCRIPTION
Following a change in the server, we are now able to read MPC184, which adds them to the result fc with label "12" (MPC). As a result, num_fields is 3 (and not 2)