### PR TITLE
ci(retro): use maps to manage DPF version and patch to test for retro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         uses: codecov/codecov-action@v5
 
   retro:
-    name: "Test DPF ${{ matrix.version.version }}${{ matrix.version.patch }} compatibility"
+    name: "Test DPF ${{ matrix.ANSYS_VERSION.version }}${{ matrix.ANSYS_VERSION.patch }} compatibility"
     if: startsWith(github.head_ref, 'main') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -128,7 +128,7 @@ jobs:
         uses: codecov/codecov-action@v5
 
   retro:
-    name: "Test DPF ${{ matrix.version.version }}${{ matrix.version.patch }} compatibility"
+    name: "Test DPF ${{ matrix.ANSYS_VERSION.version }}${{ matrix.ANSYS_VERSION.patch }} compatibility"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
[Release CI run](https://github.com/ansys/pydpf-post/actions/runs/19034976995)