### PR TITLE
test(cff): Change skipif condition for flprj tests

### DIFF
--- a/tests/test_fluid_simulation.py
+++ b/tests/test_fluid_simulation.py
@@ -74,7 +74,7 @@ class TestFluidSimulation:
 
     @pytest.mark.skipif(
         (not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0) and (os.name == "posix"),
-        reason="Failing for DPF < 2025 R2 on Linux",
+        reason="Bug due to gatebin incompatibilities for servers <26.1",
     )
     def test_simulation_flprj(self):
         simulation = post.FluidSimulation(


### PR DESCRIPTION
After the investigation from #926, it is found out that the issues in flprj tests are due to gatebin incompatibilities. These are fixed in 26.1, so we need to keep them skipped in older servers.