### PR TITLE
fix(installation): Remove dependency on direct URL for ansys-dpf-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,15 @@ jobs:
           echo "ANSYS_DPF_ACCEPT_LA=Y" >> $GITHUB_ENV
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
+      - name: "Setup Python"
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: "Install CI requirements (pydpf-core from main)"
+        shell: bash
+        run: pip install -r requirements/requirements_ci.txt
+
       - name: "Build Package"
         uses: ansys/pydpf-actions/build_package@v2.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,15 @@ jobs:
           echo "ANSYS_DPF_ACCEPT_LA=Y" >> $GITHUB_ENV
           echo "ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }}" >> $GITHUB_ENV
 
+      - name: "Setup Python"
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: "Install CI requirements (pydpf-core from main)"
+        shell: bash
+        run: pip install -r requirements/requirements_ci.txt
+
       - name: "Build Package"
         uses: ansys/pydpf-actions/build_package@v2.3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,10 @@ jobs:
           sudo apt update
           sudo apt install pandoc texlive-latex-extra latexmk
 
+      - name: "Install CI requirements (pydpf-core from main)"
+        shell: bash
+        run: pip install -r requirements/requirements_ci.txt
+
       - name: "Build Package"
         id: build-package
         uses: ansys/pydpf-actions/build_package@v2.3

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -75,6 +75,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: "Install CI requirements (pydpf-core from main)"
+        shell: bash
+        run: pip install -r requirements/requirements_ci.txt
+
       - name: "Build Package"
         uses: ansys/pydpf-actions/build_package@v2.3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
 ]
 dependencies = [
-    "ansys-dpf-core@git+https://github.com/ansys/pydpf-core.git",
+    "ansys-dpf-core",
     "scooby",
 ]
 classifiers = [

--- a/requirements/requirements_ci.txt
+++ b/requirements/requirements_ci.txt
@@ -1,0 +1,11 @@
+# This file is used by CI (and the dev main branch) to ensure the latest
+# pydpf-core main branch is installed *before* `pip install -e .` for pydpf-post.
+#
+# Install order in CI / tox:
+#   pip install -r requirements/requirements_ci.txt
+#   pip install -e .
+#
+# This approach avoids the "conflicting URLs" error that would arise if the URL
+# were hardcoded in pyproject.toml's [project.dependencies], which makes it
+# impossible to also install ansys-dpf-core as an editable local checkout.
+ansys-dpf-core @ git+https://github.com/ansys/pydpf-core.git


### PR DESCRIPTION
Fixes #981 

This pull request updates the way the `ansys-dpf-core` dependency is managed, especially in CI and development workflows. Instead of specifying the GitHub URL for the main branch directly in `pyproject.toml`, the dependency is now installed via a new requirements file during CI. This change improves flexibility and avoids conflicts when working with editable installs or local checkouts.

Dependency management improvements:

* Removed the direct GitHub URL for `ansys-dpf-core` from the `dependencies` section in `pyproject.toml`, replacing it with the standard package name to avoid conflicts and improve compatibility with editable installs.
* Added a new `requirements/requirements_ci.txt` file that installs `ansys-dpf-core` from the main branch on GitHub, with comments explaining the rationale and usage order in CI and development environments.

CI workflow updates:

* Updated the `ci.yml`, `examples.yml`, and `docs.yml` GitHub Actions workflows to install dependencies from `requirements/requirements_ci.txt` before building the package, ensuring the latest `pydpf-core` is used in CI runs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR100-R108) [[2]](diffhunk://#diff-8906835152921ef903f55779586f3a092362f65fca98df94d71801cf974ec95bR78-R81) [[3]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR93-R96)
* Added a Python setup step in the `ci.yml` workflow to ensure the correct Python version is used before installing dependencies.