### PR TITLE
fix: doctest retro in Meshes

### DIFF
--- a/src/ansys/dpf/post/meshes.py
+++ b/src/ansys/dpf/post/meshes.py
@@ -56,7 +56,7 @@ class Meshes:
     >>> # Select the second mesh by its index (0-based)
     >>> mesh_1 = meshes_split[1]
     >>> # Select the mesh for material=1 and elshape=2
-    >>> mesh_2 = meshes_split[{elt_prop.material: 1, elt_prop.element_shape: 2}]
+    >>> mesh_2 = meshes_split[{elt_prop.material: 1, elt_prop.element_shape: 1}]
     """
 
     def __init__(self, meshes_container: MeshesContainer):


### PR DESCRIPTION
This is currently preventing from releasing with `DPF 261` and `ansys-dpf-core 0.16.0`.

Here is a passing [release CI](https://github.com/ansys/pydpf-post/actions/runs/25041339724)