### PR TITLE
fix: use packaging.version for server version comparisons

### DIFF
--- a/src/ansys/dpf/post/index.py
+++ b/src/ansys/dpf/post/index.py
@@ -31,6 +31,7 @@ from typing import List, Union
 import weakref
 
 import ansys.dpf.core as dpf
+from ansys.dpf.core.check_version import get_server_version, meets_version
 
 from ansys.dpf import post
 
@@ -181,7 +182,7 @@ class MeshIndex(Index):
             fc = self._fc()
             if fc is not None:
                 merge_op = dpf.operators.utility.merge_scopings(server=fc._server)
-                if float(fc._server.version) >= 5.0:
+                if meets_version(get_server_version(fc._server), "5.0"):
                     scopings = dpf.operators.utility.extract_scoping(
                         field_or_fields_container=fc,
                         server=fc._server,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,8 +372,8 @@ def license_context():
         yield
 
 
-SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_13_0 = meets_version(
-    get_server_version(core._global_server()), "13.0"
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0 = meets_version(
+    get_server_version(core._global_server()), "2027.1.0pre0"
 )  # 2027.1.pre0
 
 SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0 = meets_version(


### PR DESCRIPTION
Server version now reports full calendar version (e.g. '2027.1.0pre0') starting with pydpf-core 426512a. Float-based comparisons break with this format.

- Replace float(server.version) comparison in index.py with meets_version()
- Rename SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_13_0 to SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0 and update version string to '2027.1.0pre0' in tests/conftest.py