### PR TITLE
Improve shell layer selection

### DIFF
--- a/src/ansys/dpf/post/result_workflows/_sub_workflows.py
+++ b/src/ansys/dpf/post/result_workflows/_sub_workflows.py
@@ -103,9 +103,10 @@ def _create_averaging_workflow(
         else:
             operator_name = "to_elemental_fc"
         mesh_average_op = create_operator_callable(name=operator_name)
-        if server.meet_version("10.0") and shell_layer is not None:
+        if server.meet_version("10.0"):
             mesh_average_op.connect(26, True)  # merge solid and shell fields
-            mesh_average_op.connect(27, shell_layer.value)
+            if shell_layer is not None:
+                mesh_average_op.connect(27, shell_layer.value)
         average_wf.add_operator(mesh_average_op)
         mesh_average_op.connect(0, mesh_averaging_input_fwd, 0)
         averaged_data_fwd.connect(0, mesh_average_op, 0)
@@ -254,8 +255,7 @@ def _create_initial_result_workflow(
             _WfNames.output_data, initial_result_op, 0
         )
 
-    if hasattr(initial_result_op.inputs, "shell_layer"):
-        if server.meet_version("10.0") and shell_layer is not None:
+        if server.meet_version("10.0"):
             initial_result_op.connect(
                 26, False
             )  # do not split (=merge) solid and shell fields

--- a/src/ansys/dpf/post/result_workflows/_sub_workflows.py
+++ b/src/ansys/dpf/post/result_workflows/_sub_workflows.py
@@ -259,9 +259,10 @@ def _create_initial_result_workflow(
             initial_result_op.connect(
                 26, False
             )  # do not split (=merge) solid and shell fields
-        _connect_any(
-            initial_result_op.inputs.shell_layer, forward_shell_layer_op.outputs.any
-        )
+        if hasattr(initial_result_op.inputs, "shell_layer"):
+            _connect_any(
+                initial_result_op.inputs.shell_layer, forward_shell_layer_op.outputs.any
+            )
 
     initial_result_workflow.set_input_name(
         "time_scoping", initial_result_op.inputs.time_scoping

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2695,6 +2695,7 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental)
+        op.connect(26, False)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2710,6 +2711,7 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.nodal)
+        op.connect(26, False)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2740,6 +2742,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.nodal)
+        op.connect(26, False)
+
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2755,6 +2759,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental)
+        op.connect(26, False)
+
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2785,6 +2791,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental)
+        op.connect(26, False)
+
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2800,6 +2808,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.nodal)
+        op.connect(26, False)
+
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2841,6 +2851,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental)
+        op.connect(26, False)
+
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2856,6 +2868,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.nodal)
+        op.connect(26, False)
+
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -2890,6 +2904,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.nodal)
+        op.connect(26, False)
+
         principal_op = modal_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_2()[0]
@@ -2909,6 +2925,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental)
+        op.connect(26, False)
+
         principal_op = modal_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_3()[0]
@@ -2943,6 +2961,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental_nodal)
+        op.connect(26, False)
+
         equivalent_op = modal_simulation._model.operator(name="eqv_fc")
         equivalent_op.connect(0, op.outputs.fields_container)
         average_op = modal_simulation._model.operator(name="to_nodal_fc")
@@ -2962,6 +2982,8 @@ class TestModalMechanicalSimulation:
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental_nodal)
+        op.connect(26, False)
+
         equivalent_op = modal_simulation._model.operator(name="eqv_fc")
         equivalent_op.connect(0, op.outputs.fields_container)
         average_op = modal_simulation._model.operator(name="to_elemental_fc")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1628,6 +1628,70 @@ def test_shell_layer_extraction_contacts(
         assert max_val > 7.7 and max_val < 7.8
 
 
+def test_elemental_shell_mid_layer_with_contact_matches_core(
+    mixed_shell_solid_with_contact_simulation,
+):
+    """Check elemental shell-layer extraction on a model containing contact."""
+    if not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0:
+        return
+
+    simulation = mixed_shell_solid_with_contact_simulation
+    core_stress = dpf.operators.result.stress(
+        streams_container=simulation._model.metadata.meshed_region._stream_provider,
+        requested_location=locations.elemental,
+        shell_layer=shell_layers.mid,
+        split_shells=False,
+    ).outputs.fields_container()[0]
+    core_stress_xx = dpf.operators.logic.component_selector(
+        field=core_stress, component_number=[0]
+    ).outputs.field()
+    post_stress = simulation._get_result(
+        base_name="S",
+        location=locations.elemental,
+        category=ResultCategory.matrix,
+        components=["X"],
+        shell_layer=shell_layers.mid,
+    )._fc
+
+    assert len(post_stress) == 1
+    assert post_stress[0].scoping.size == core_stress.scoping.size == 20
+    for element_id in [65, 66, 67, 68]:
+        np.testing.assert_allclose(
+            post_stress[0].get_entity_data_by_id(element_id),
+            core_stress_xx.get_entity_data_by_id(element_id),
+        )
+
+
+@pytest.mark.parametrize(
+    ("skin", "expected_entity_count"),
+    [
+        (True, 52),
+        ([65, 66, 67, 68], 4),
+        ([65, 66, 67, 68, 15], 10),
+    ],
+)
+def test_elemental_skin_with_contact_merges_solid_and_shell_fields(
+    mixed_shell_solid_with_contact_simulation, skin, expected_entity_count
+):
+    """Check that elemental skin stress does not remain split on ``elshape``."""
+    if not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0:
+        return
+
+    stress = mixed_shell_solid_with_contact_simulation._get_result(
+        base_name="S",
+        location=locations.elemental,
+        category=ResultCategory.matrix,
+        components=["X"],
+        skin=skin,
+    )._fc
+
+    assert stress.labels == ["time"]
+    assert len(stress) == 1
+    assert stress[0].location == locations.elemental
+    assert stress[0].component_count == 1
+    assert stress[0].scoping.size == expected_entity_count
+
+
 @pytest.mark.parametrize("skin", all_configuration_ids)
 @pytest.mark.parametrize("result_name", ["stress", "elastic_strain", "displacement"])
 @pytest.mark.parametrize("mode", [None, "principal", "equivalent"])

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2686,7 +2686,7 @@ class TestModalMechanicalSimulation:
 
     def test_stress_elemental(self, modal_simulation):
         result = modal_simulation.stress_elemental(components=1, set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("SX")
@@ -2701,7 +2701,7 @@ class TestModalMechanicalSimulation:
 
     def test_stress_nodal(self, modal_simulation):
         result = modal_simulation.stress_nodal(components=1, set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("SX")
@@ -2731,7 +2731,7 @@ class TestModalMechanicalSimulation:
 
     def test_stress_principal_nodal(self, modal_simulation):
         result = modal_simulation.stress_principal_nodal(components=2, set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S2")
@@ -2746,7 +2746,7 @@ class TestModalMechanicalSimulation:
 
     def test_stress_principal_elemental(self, modal_simulation):
         result = modal_simulation.stress_principal_elemental(components=3, set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S3")
@@ -2776,7 +2776,7 @@ class TestModalMechanicalSimulation:
 
     def test_stress_eqv_von_mises_elemental(self, modal_simulation):
         result = modal_simulation.stress_eqv_von_mises_elemental(set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S_eqv")
@@ -2791,7 +2791,7 @@ class TestModalMechanicalSimulation:
 
     def test_stress_eqv_von_mises_nodal(self, modal_simulation):
         result = modal_simulation.stress_eqv_von_mises_nodal(set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S_eqv")
@@ -2832,7 +2832,7 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_elemental(self, modal_simulation):
         result = modal_simulation.elastic_strain_elemental(components=1, set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPELX")
@@ -2847,7 +2847,7 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_nodal(self, modal_simulation):
         result = modal_simulation.elastic_strain_nodal(components=1, set_ids=[2])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPELX")
@@ -2881,7 +2881,7 @@ class TestModalMechanicalSimulation:
         result = modal_simulation.elastic_strain_principal_nodal(
             components=2, set_ids=[2]
         )
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")
@@ -2900,7 +2900,7 @@ class TestModalMechanicalSimulation:
         result = modal_simulation.elastic_strain_principal_elemental(
             components=3, set_ids=[2]
         )
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")
@@ -2934,7 +2934,7 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_eqv_von_mises_nodal(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")
@@ -2953,7 +2953,7 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_eqv_von_mises_elemental(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_elemental(set_ids=[1])
-        assert len(result._fc) == 2
+        assert len(result._fc) == 1
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1686,8 +1686,10 @@ def test_elemental_skin_with_contact_merges_solid_and_shell_fields(
         skin=skin,
     )._fc
 
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
-        # Solid and shell fields are merged into a single field
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 or expected_entity_count == 4:
+        # Solid and shell fields are merged into a single field for newer version
+        # For the expected_entity_count == 4 only the shell elements are selected,
+        # so the result is also a single field
         assert stress.labels == ["time"]
         assert len(stress) == 1
     else:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1686,7 +1686,7 @@ def test_elemental_skin_with_contact_merges_solid_and_shell_fields(
         skin=skin,
     )._fc
 
-    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0:
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0:
         # Solid and shell fields are merged into a single field
         assert stress.labels == ["time"]
         assert len(stress) == 1

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -62,6 +62,7 @@ from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_9_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_9_1,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0,
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_12_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0,
     ReferenceCsvFilesNodal,
@@ -2693,7 +2694,7 @@ class TestModalMechanicalSimulation:
     def test_stress_elemental(self, modal_simulation):
         result = modal_simulation.stress_elemental(components=1, set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2712,7 +2713,7 @@ class TestModalMechanicalSimulation:
     def test_stress_nodal(self, modal_simulation):
         result = modal_simulation.stress_nodal(components=1, set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2746,7 +2747,7 @@ class TestModalMechanicalSimulation:
     def test_stress_principal_nodal(self, modal_simulation):
         result = modal_simulation.stress_principal_nodal(components=2, set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2766,7 +2767,7 @@ class TestModalMechanicalSimulation:
     def test_stress_principal_elemental(self, modal_simulation):
         result = modal_simulation.stress_principal_elemental(components=3, set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2801,7 +2802,7 @@ class TestModalMechanicalSimulation:
     def test_stress_eqv_von_mises_elemental(self, modal_simulation):
         result = modal_simulation.stress_eqv_von_mises_elemental(set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2821,7 +2822,7 @@ class TestModalMechanicalSimulation:
     def test_stress_eqv_von_mises_nodal(self, modal_simulation):
         result = modal_simulation.stress_eqv_von_mises_nodal(set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2867,7 +2868,7 @@ class TestModalMechanicalSimulation:
     def test_elastic_strain_elemental(self, modal_simulation):
         result = modal_simulation.elastic_strain_elemental(components=1, set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2887,7 +2888,7 @@ class TestModalMechanicalSimulation:
     def test_elastic_strain_nodal(self, modal_simulation):
         result = modal_simulation.elastic_strain_nodal(components=1, set_ids=[2])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2926,7 +2927,7 @@ class TestModalMechanicalSimulation:
             components=2, set_ids=[2]
         )
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2950,7 +2951,7 @@ class TestModalMechanicalSimulation:
             components=3, set_ids=[2]
         )
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
@@ -2989,7 +2990,7 @@ class TestModalMechanicalSimulation:
     def test_elastic_strain_eqv_von_mises_nodal(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [1]
@@ -3014,7 +3015,7 @@ class TestModalMechanicalSimulation:
     def test_elastic_strain_eqv_von_mises_elemental(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_elemental(set_ids=[1])
         expected_merged_field_count = (
-            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_11_0 else 2
         )
         assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [1]

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1685,11 +1685,17 @@ def test_elemental_skin_with_contact_merges_solid_and_shell_fields(
         skin=skin,
     )._fc
 
-    assert stress.labels == ["time"]
-    assert len(stress) == 1
+    if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0:
+        # Solid and shell fields are merged into a single field
+        assert stress.labels == ["time"]
+        assert len(stress) == 1
+    else:
+        # Older servers keep the results split on the 'elshape' label
+        assert sorted(stress.labels) == ["elshape", "time"]
+        assert len(stress) == 2
     assert stress[0].location == locations.elemental
     assert stress[0].component_count == 1
-    assert stress[0].scoping.size == expected_entity_count
+    assert sum(field.scoping.size for field in stress) == expected_entity_count
 
 
 @pytest.mark.parametrize("skin", all_configuration_ids)
@@ -2686,7 +2692,10 @@ class TestModalMechanicalSimulation:
 
     def test_stress_elemental(self, modal_simulation):
         result = modal_simulation.stress_elemental(components=1, set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("SX")
@@ -2702,7 +2711,10 @@ class TestModalMechanicalSimulation:
 
     def test_stress_nodal(self, modal_simulation):
         result = modal_simulation.stress_nodal(components=1, set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("SX")
@@ -2733,7 +2745,10 @@ class TestModalMechanicalSimulation:
 
     def test_stress_principal_nodal(self, modal_simulation):
         result = modal_simulation.stress_principal_nodal(components=2, set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S2")
@@ -2750,7 +2765,10 @@ class TestModalMechanicalSimulation:
 
     def test_stress_principal_elemental(self, modal_simulation):
         result = modal_simulation.stress_principal_elemental(components=3, set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S3")
@@ -2782,7 +2800,10 @@ class TestModalMechanicalSimulation:
 
     def test_stress_eqv_von_mises_elemental(self, modal_simulation):
         result = modal_simulation.stress_eqv_von_mises_elemental(set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S_eqv")
@@ -2799,7 +2820,10 @@ class TestModalMechanicalSimulation:
 
     def test_stress_eqv_von_mises_nodal(self, modal_simulation):
         result = modal_simulation.stress_eqv_von_mises_nodal(set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("S_eqv")
@@ -2842,7 +2866,10 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_elemental(self, modal_simulation):
         result = modal_simulation.elastic_strain_elemental(components=1, set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPELX")
@@ -2859,7 +2886,10 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_nodal(self, modal_simulation):
         result = modal_simulation.elastic_strain_nodal(components=1, set_ids=[2])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPELX")
@@ -2895,7 +2925,10 @@ class TestModalMechanicalSimulation:
         result = modal_simulation.elastic_strain_principal_nodal(
             components=2, set_ids=[2]
         )
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")
@@ -2916,7 +2949,10 @@ class TestModalMechanicalSimulation:
         result = modal_simulation.elastic_strain_principal_elemental(
             components=3, set_ids=[2]
         )
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")
@@ -2952,7 +2988,10 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_eqv_von_mises_nodal(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")
@@ -2974,7 +3013,10 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_eqv_von_mises_elemental(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_elemental(set_ids=[1])
-        assert len(result._fc) == 1
+        expected_merged_field_count = (
+            1 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 else 2
+        )
+        assert len(result._fc) == expected_merged_field_count
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2966,6 +2966,7 @@ class TestModalMechanicalSimulation:
         equivalent_op = modal_simulation._model.operator(name="eqv_fc")
         equivalent_op.connect(0, op.outputs.fields_container)
         average_op = modal_simulation._model.operator(name="to_nodal_fc")
+        average_op.connect(26, True)
         average_op.connect(0, equivalent_op.outputs.fields_container)
         field_ref = average_op.outputs.fields_container()[0]
         assert field.component_count == 1
@@ -2987,6 +2988,8 @@ class TestModalMechanicalSimulation:
         equivalent_op = modal_simulation._model.operator(name="eqv_fc")
         equivalent_op.connect(0, op.outputs.fields_container)
         average_op = modal_simulation._model.operator(name="to_elemental_fc")
+        average_op.connect(26, True)
+
         average_op.connect(0, equivalent_op.outputs.fields_container)
         field_ref = average_op.outputs.fields_container()[0]
         assert field.component_count == 1


### PR DESCRIPTION
There were two independent issues

1. Shell layer selection was applied twice for elemental results (not is_nodal in _create_initial_result_workflow). This fixes the initial bug, because with the second selection the shell element were somehow removed.
2. Fields were not merged if no shell layer was selected. With the fix, shell layers are always merged, even if the number of shell layers differ in different parts of the model. This corresponds split_shells=False on the result operators, which is not the default. This is convenient for downstream processing. If we want to keep the default behaviour of dpf core, we could expose the split_shell_layer as an an input pydpf-post.

closes #1027