### PR TITLE
fix: migrate pydpf-post to DpfPlotter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,12 @@ Source = "https://github.com/ansys/pydpf-post"
 [project.optional-dependencies]
 graphics = [
     "pyvista>=0.24.0",
+    "ansys-tools-visualization-interface>=0.13.0",
 ]
 
 plotting = [
     "pyvista>=0.24.0",
+    "ansys-tools-visualization-interface>=0.13.0",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -12,5 +12,6 @@ sphinx-gallery==0.21.0
 ansys_sphinx_theme==1.7.2
 sphinx-autodoc-typehints==3.0.1
 pyvista==0.47.3
+ansys-tools-visualization-interface>=0.13.0
 vtk==9.6.1
 sphinx-design===0.6.1

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -3,4 +3,5 @@ pytest-cov==7.1.0
 pytest-rerunfailures==16.2
 pytest==9.0.3
 pyvista==0.47.3
+ansys-tools-visualization-interface>=0.13.0
 vtk==9.6.1

--- a/src/ansys/dpf/post/result_data.py
+++ b/src/ansys/dpf/post/result_data.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 #
 #
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -29,7 +30,7 @@ from textwrap import wrap
 from ansys.dpf.core import FieldsContainer, Operator
 from ansys.dpf.core import errors as core_errors
 from ansys.dpf.core.common import DefinitionLabels, types
-from ansys.dpf.core.plotter import Plotter as DpfPlotter
+from ansys.dpf.core.plotter import DpfPlotter, plot_chart
 
 from ansys.dpf.post import errors as dpf_errors
 from ansys.dpf.post.result_evaluation import ResultEvaluator
@@ -304,11 +305,16 @@ class ResultData:
         The obtained figure depends on the support. It can be a meshed region or a
         time frequency support.  For a transient analysis, plot the last result.
 
-        This method is private. It publishes a VTK file and uses PyVista to print from this file.
+        This method is private. It uses the DPF plotter to display the result.
         """
         self._evaluate_result()
-        pl = DpfPlotter(self._evaluator._model.metadata.meshed_region)
-        pl._plot_contour_using_vtk_file(self.result_fields_container)
+        mesh = self._evaluator._model.metadata.meshed_region
+        pl = DpfPlotter()
+        pl.add_fields_container(
+            fields_container=self.result_fields_container,
+            meshed_region=mesh,
+        )
+        pl.show_figure()
 
     def _sort_fields_container_with_labels(self, option_id, display_option):
         ids = option_id
@@ -394,13 +400,8 @@ class ResultData:
 
         # If plotting on a path
         if self._evaluator._path is not None:
-            # Try and use the new DpfPlotter from PyDPF-Core
-            try:
-                from ansys.dpf.core.plotter import DpfPlotter as DpfPlotterObj
-            except ImportError:
-                raise dpf_errors.CoreVersionError(version="0.3.4")
             # Initialize the plotter
-            pl = DpfPlotterObj(**kwargs)
+            pl = DpfPlotter(**kwargs)
             # Sort the fields according to options
             new_fields_container = self._sort_fields_container_with_labels(
                 option_id, display_option
@@ -422,8 +423,8 @@ class ResultData:
 
         # If not plotting on a path
         else:
-            # Initialize a Plotter
-            pl = DpfPlotter(self._evaluator._model.metadata.meshed_region, **kwargs)
+            # Initialize the plotter
+            pl = DpfPlotter(**kwargs)
             # Create an equivalent field container
             if len(self.result_fields_container) == 1:
                 fc = self.result_fields_container
@@ -431,7 +432,14 @@ class ResultData:
                 # sorts and creates a new fields_container with only the desired labels
                 fc = self._sort_fields_container_with_labels(option_id, display_option)
 
-            pl.plot_contour(fc, **kwargs)
+            pl.add_fields_container(
+                fields_container=fc,
+                meshed_region=self._evaluator._model.metadata.meshed_region,
+                show_axes=kwargs.pop("show_axes", True),
+                **kwargs,
+            )
+            kwargs.pop("notebook", None)
+            pl.show_figure(**kwargs)
 
     def _plot_chart(self):
         """Plot the minimum and maximum result values over time.
@@ -448,5 +456,4 @@ class ResultData:
         # res_op = self._evaluator._result_operator
         # res_op.inputs.time_scoping.connect(timeids)
         # new_fields_container = res_op.get_output(0, types.fields_container)
-        pl = DpfPlotter(None)
-        pl.plot_chart(self.result_fields_container)
+        plot_chart(self.result_fields_container)


### PR DESCRIPTION
## Summary
Migrate pydpf-post away from deprecated DPF Core Plotter APIs.

## Changes
- Use DpfPlotter.add_fields_container and show_figure for contour plots.
- Use module-level plot_chart for chart plots.
- Remove legacy Plotter construction and plot_contour/plot_chart calls.

## Validation
- Reported regression test: 1 passed against breaking pydpf-core source.
- ResultData test module: 34 passed.
- Adjacent plotting tests: 696 passed, 20 xfailed, 4 xpassed.
- All pre-commit hooks passed.