### PR TITLE
Add `read_beams` option to internal workflow creation

### DIFF
--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -85,6 +85,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         averaging_config: AveragingConfig = AveragingConfig(),
         rescoping: Optional[_Rescoping] = None,
         shell_layer: Optional[shell_layers] = None,
+        read_beams: Optional[bool] = None,
     ) -> Tuple[dpf.Workflow, Union[str, list[str], None], str]:
         """Generate (without evaluating) the Workflow to extract results."""
         result_workflow_inputs = _create_result_workflow_inputs(
@@ -101,6 +102,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             averaging_config=averaging_config,
             rescoping=rescoping,
             shell_layer=shell_layer,
+            read_beams=read_beams,
         )
         result_workflows = _create_result_workflows(
             server=self._model._server,

--- a/src/ansys/dpf/post/modal_mechanical_simulation.py
+++ b/src/ansys/dpf/post/modal_mechanical_simulation.py
@@ -74,6 +74,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         averaging_config: AveragingConfig = AveragingConfig(),
         rescoping: Optional[_Rescoping] = None,
         shell_layer: Optional[shell_layers] = None,
+        read_beams: Optional[bool] = None,
     ) -> Tuple[dpf.Workflow, Union[str, list[str], None], str]:
         """Generate (without evaluating) the Workflow to extract results."""
         result_workflow_inputs = _create_result_workflow_inputs(
@@ -88,6 +89,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             averaging_config=averaging_config,
             rescoping=rescoping,
             shell_layer=shell_layer,
+            read_beams=read_beams,
         )
         result_workflows = _create_result_workflows(
             server=self._model._server,

--- a/src/ansys/dpf/post/result_workflows/_build_workflow.py
+++ b/src/ansys/dpf/post/result_workflows/_build_workflow.py
@@ -116,6 +116,7 @@ class _CreateWorkflowInputs:
     should_extract_components: bool
     averaging_config: AveragingConfig
     shell_layer: Optional[shell_layers]
+    read_beams: Optional[bool] = None
     sweeping_phase_workflow_inputs: Optional[_SweepingPhaseWorkflowInputs] = None
     rescoping_workflow_inputs: Optional[_Rescoping] = None
 
@@ -173,6 +174,7 @@ def _create_result_workflows(
         server=server,
         is_nodal=is_nodal,
         shell_layer=create_workflow_inputs.shell_layer,
+        read_beams=create_workflow_inputs.read_beams,
         create_operator_callable=create_operator_callable,
     )
 
@@ -275,6 +277,7 @@ def _create_result_workflow_inputs(
     averaging_config: AveragingConfig,
     shell_layer: Optional[shell_layers],
     rescoping: Optional[_Rescoping] = None,
+    read_beams: Optional[bool] = None,
     amplitude: bool = False,
     sweeping_phase: Union[float, None] = 0.0,
 ) -> _CreateWorkflowInputs:
@@ -327,4 +330,5 @@ def _create_result_workflow_inputs(
         averaging_config=averaging_config,
         rescoping_workflow_inputs=rescoping,
         shell_layer=shell_layer,
+        read_beams=read_beams,
     )

--- a/src/ansys/dpf/post/result_workflows/_sub_workflows.py
+++ b/src/ansys/dpf/post/result_workflows/_sub_workflows.py
@@ -200,12 +200,16 @@ def _create_initial_result_workflow(
     name: str,
     server,
     shell_layer: Optional[shell_layers],
+    read_beams: Optional[bool],
     is_nodal: bool,
     create_operator_callable: _CreateOperatorCallable,
 ):
     initial_result_workflow = Workflow(server=server)
 
     initial_result_op = create_operator_callable(name=name)
+
+    if read_beams is not None and hasattr(initial_result_op.inputs, "read_beams"):
+        initial_result_op.inputs.read_beams.connect(read_beams)
 
     initial_result_workflow.set_input_name(_WfNames.mesh, initial_result_op, 7)
     initial_result_workflow.set_input_name(_WfNames.location, initial_result_op, 9)

--- a/src/ansys/dpf/post/static_mechanical_simulation.py
+++ b/src/ansys/dpf/post/static_mechanical_simulation.py
@@ -70,6 +70,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         averaging_config: AveragingConfig = AveragingConfig(),
         rescoping: Optional[_Rescoping] = None,
         shell_layer: Optional[shell_layers] = None,
+        read_beams: Optional[bool] = None,
     ) -> Tuple[core.Workflow, Union[str, list[str], None], str]:
         """Generate (without evaluating) the Workflow to extract results."""
         result_workflow_inputs = _create_result_workflow_inputs(
@@ -84,6 +85,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             averaging_config=averaging_config,
             rescoping=rescoping,
             shell_layer=shell_layer,
+            read_beams=read_beams,
         )
         result_workflows = _create_result_workflows(
             server=self._model._server,

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -72,6 +72,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         averaging_config: AveragingConfig = AveragingConfig(),
         rescoping: Optional[_Rescoping] = None,
         shell_layer: Optional[shell_layers] = None,
+        read_beams: Optional[bool] = None,
     ) -> Tuple[dpf.Workflow, Union[str, list[str], None], str]:
         """Generate (without evaluating) the Workflow to extract results."""
         result_workflow_inputs = _create_result_workflow_inputs(
@@ -86,6 +87,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             averaging_config=averaging_config,
             rescoping=rescoping,
             shell_layer=shell_layer,
+            read_beams=read_beams,
         )
         result_workflows = _create_result_workflows(
             server=self._model._server,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -4834,7 +4834,6 @@ def test_read_beams_option(beam_example, read_beams):
     assert len(fields_container) == 1
 
     field: dpf.Field = fields_container[0]
-    assert field.location == locations.elemental
 
     # When read_beams is None, the operator default applies.
     # The default was False until version 2027.1 pre0 excluded.

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -38,7 +38,7 @@ from ansys.dpf.core import (
     operators,
     shell_layers,
 )
-from ansys.dpf.core.common import locations
+from ansys.dpf.core.common import locations, types
 import numpy as np
 import pytest
 from pytest import fixture
@@ -4669,6 +4669,48 @@ def test_beam_results_on_skin(beam_example):
         assert element_count_dict[element_types.Line2.value] == 40
 
     assert converted_field.max().data[0] == pytest.approx(190, 1e-2)
+
+
+@pytest.mark.parametrize("read_beams", [None, True, False])
+def test_read_beams_option(beam_example, read_beams):
+    simulation: StaticMechanicalSimulation = post.load_simulation(
+        data_sources=beam_example,
+        simulation_type=AvailableSimulationTypes.static_mechanical,
+    )
+
+    selection, rescoping = simulation._build_selection(
+        base_name="S",
+        category=ResultCategory.equivalent,
+        selection=None,
+        times=None,
+        set_ids=None,
+    )
+
+    wf, _, _ = simulation._get_result_workflow(
+        base_name="S",
+        location=dpf.locations.elemental,
+        category=ResultCategory.equivalent,
+        selection=selection,
+        rescoping=rescoping,
+        read_beams=read_beams,
+    )
+
+    fields_container = wf.get_output(_WfNames.output_data, types.fields_container)
+
+    assert len(fields_container) == 1
+
+    field: dpf.Field = fields_container[0]
+    assert field.location == locations.elemental
+
+    # When read_beams is None, the operator default applies.
+    # The default was False until version 2027.1 pre0 excluded.
+    if read_beams is True or (
+        read_beams is None and SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2027_1_PRE0
+    ):
+        assert np.isclose(field.min().data[0], 0.4351, rtol=1.0e-3)
+        assert np.isclose(field.max().data[0], 5.512, rtol=1.0e-3)
+    else:
+        assert field.size == 0
 
 
 def test_nodal_averaging_on_elemental_scoping(average_per_body_two_cubes):


### PR DESCRIPTION
In 2027 R1, the default of the `read_beams` input for MAPDL operators has changed from False to True. In Result Explorer we don't want to get stress/strain/etc beam results, so we need a way to set this input on the result operator.

Exposing it on the internal `MechanicalSimulation._get_result_workflow` functions (which are the Result Explorer entry points) as an optional input.

No changes to the pydpf-post API or behavior.